### PR TITLE
Fix example

### DIFF
--- a/src/Composition.tsx
+++ b/src/Composition.tsx
@@ -1,53 +1,63 @@
-import { render, ShaderMaterialProps, useFrame } from "@react-three/fiber";
-import { ThreeCanvas } from "@remotion/three";
-import { useRef } from "react";
-import { useCurrentFrame, useVideoConfig } from "remotion";
-import { fragment, vertex } from "./shaders";
+import {useState} from 'react';
+import {ShaderMaterialProps, useFrame} from '@react-three/fiber';
+import {ThreeCanvas} from '@remotion/three';
+import {useMemo, useRef} from 'react';
+import {useCurrentFrame, useVideoConfig} from 'remotion';
+import {fragment, vertex} from './shaders';
 
 const CanvasContent = (props: {
-  width: number,
-  height: number,
-  time: number
+	width: number;
+	height: number;
+	time: number;
 }) => {
-  const {width, height, time} = props;
+	const {width, height, time} = props;
+	const [initialTime] = useState(() => time);
+	const timeRef = useRef(time);
+	timeRef.current = time;
 	const material = useRef();
-  useFrame(() => {
-    if(!material.current) return;
-    const mat = material.current as ShaderMaterialProps;
-    mat.uniforms.u_time.value = time;
-    mat.needsUpdate = true;
-  });
 
-  return <mesh>
-    <planeGeometry args={[width, height, 1]} />
-    <shaderMaterial
-      vertexShader={vertex}
-      fragmentShader={fragment}
-      uniforms={{
-        u_time: { value: time },
-        u_resolution: { value: { x: width, y: height } }
-      }}
-      ref={material}
-    />
-  </mesh>
-}
+	const uniforms = useMemo(() => {
+		return {
+			u_time: {value: initialTime},
+			u_resolution: {value: {x: width, y: height}},
+		};
+	}, [height, initialTime, width]);
+
+	useFrame(() => {
+		if (!material.current) return;
+		const mat = material.current as ShaderMaterialProps;
+		mat.uniforms.u_time.value = time;
+	});
+
+	return (
+		<mesh>
+			<planeGeometry args={[width, height, 1]} />
+			<shaderMaterial
+				ref={material}
+				vertexShader={vertex}
+				fragmentShader={fragment}
+				uniforms={uniforms}
+			/>
+		</mesh>
+	);
+};
 
 export const MyComposition = () => {
-  const frame = useCurrentFrame();
-  const { fps, width, height } = useVideoConfig();
-  const time = frame / fps;
+	const frame = useCurrentFrame();
+	const {fps, width, height} = useVideoConfig();
+	const time = frame / fps;
 
-  return (
-    <ThreeCanvas
-      orthographic={true}
-      width={width}
-      height={height}
-      style={{
-        backgroundColor: "black",
-      }}
-      camera={{ position: [0, 0, 1] }}
-    >
-      <CanvasContent {...{width, height, time}} />
-    </ThreeCanvas>
-  );
+	return (
+		<ThreeCanvas
+			orthographic
+			width={width}
+			height={height}
+			style={{
+				backgroundColor: 'black',
+			}}
+			camera={{position: [0, 0, 1]}}
+		>
+			<CanvasContent {...{width, height, time}} />
+		</ThreeCanvas>
+	);
 };

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -7,7 +7,7 @@ export const RemotionRoot: React.FC = () => {
 			<Composition
 				id="MyComp"
 				component={MyComposition}
-				durationInFrames={60}
+				durationInFrames={500}
 				fps={30}
 				width={1280}
 				height={720}


### PR DESCRIPTION
If the `uniforms` value is not memoized, a new material object was created on every time change.
And `material.current` was referring to the initial material, therefore the update was not recognized.

Discussion about this is found here https://discourse.threejs.org/t/why-float-uniform-is-not-updating/50068/5

This is indeed very unintuitive for me as well. Seems like a bug.